### PR TITLE
add node counter, optimistic updates and partial data updates

### DIFF
--- a/convex/reactflow/nodes.ts
+++ b/convex/reactflow/nodes.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import { addEdge, applyNodeChanges } from "reactflow";
 import { mutation, query } from "../_generated/server";
-import { clientData } from "../shared";
+import { ClientData, clientData } from "../shared";
 import { canReadDiagramData, canWriteDiagramData } from "./access";
 import { nodeChangeValidator } from "./types";
 
@@ -189,9 +189,10 @@ export const getData = query({
     }
     const counterId = node.node.data.counterId;
     const counter = counterId && (await ctx.db.get(counterId));
+    const { counterId: _, ...restData } = node.node.data;
     return {
-      count: counter?.count ?? 0, count2: node.node.data.count2 ?? 0
-    };
+      count: counter?.count ?? 0, ...restData
+    } as ClientData;
   },
 });
 

--- a/convex/reactflow/nodes.ts
+++ b/convex/reactflow/nodes.ts
@@ -16,7 +16,7 @@ export const get = query({
       .withIndex("diagram", (q) => q.eq("diagramId", args.diagramId))
       .collect();
     // Modify data returned, join it, etc. here
-    const nodesWithCounts = await Promise.all(
+    const nodesWithCount = await Promise.all(
       all.map(async (node) => {
         const count =
           node.node.data.counterId &&
@@ -24,13 +24,13 @@ export const get = query({
         return {
           ...node.node,
           data: {
+            ...node.node.data,
             count: count?.count,
-            count2: node.node.data.count2 ,
           },
         };
       }),
     );
-    return nodesWithCounts;
+    return nodesWithCount;
   },
 });
 

--- a/convex/reactflow/nodes.ts
+++ b/convex/reactflow/nodes.ts
@@ -24,7 +24,7 @@ export const get = query({
         return {
           ...node.node,
           data: {
-            count: count?.count ?? 0,
+            count: count?.count,
             count2: node.node.data.count2 ,
           },
         };

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -5,7 +5,8 @@ import { edgeValidator, nodeValidator } from "./reactflow/types";
 
 export const customData = v.object({
   counterId: v.optional(v.id("counters")),
-  // foo: v.string(),
+  count2: v.optional(v.number()),
+  foo: v.string(),
 });
 
 export const edgeData = v.object({

--- a/convex/shared.ts
+++ b/convex/shared.ts
@@ -2,5 +2,7 @@ import { Infer, v } from "convex/values";
 
 export type ClientData = Infer<typeof clientData>;
 export const clientData = v.object({
-  count: v.number(),
+  count: v.optional(v.number()),
+  count2: v.optional(v.number()),
+  foo: v.string(),
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,7 +207,7 @@ function Content() {
           diagramId,
           nodeId,
           position,
-          data: { count: randomValue },
+          data: { count: randomValue, count2: randomValue, foo: "bar" },
           sourceNode: connectSource,
         });
         setConnectSource(undefined);

--- a/src/components/CounterNode.tsx
+++ b/src/components/CounterNode.tsx
@@ -4,15 +4,42 @@ import { api } from "../../convex/_generated/api";
 import { ClientData } from "../../convex/shared";
 
 export default function CounterNode({ id, data }: NodeProps<ClientData>) {
-  const updateData = useMutation(api.reactflow.nodes.updateData);
+  const updateData = useMutation(api.reactflow.nodes.updateData).withOptimisticUpdate(
+    (store, args) => {
+      const nodes = store.getQuery(api.reactflow.nodes.get, { diagramId }) ?? [];
+      const updatedNodes = nodes.map(node => {
+        if (node.id === args.nodeId) {
+          return {
+            ...node,
+            data: {
+              ...node.data,
+              ...args.data
+            }
+          };
+        }
+        return node;
+      });
+      store.setQuery(api.reactflow.nodes.get, { diagramId }, updatedNodes);
+    }
+  );
+
   const diagramId = window.location.hash.slice(1);
 
-  const incrementCounter = () => {
+  const incrementTableCounter = () => {
     // Use the new updateData mutation
     updateData({
       diagramId,
       nodeId: id,
-      data: { count: data.count + 1 },
+      data: { count: (data.count ?? 0) + 1 },
+    });
+  };
+
+  const incrementNodeCounter = () => {
+    // Use    the new updateData mutation
+    updateData({
+      diagramId,
+      nodeId: id,
+      data: { count2: (data.count2 ?? 0) + 1 },
     });
   };
 
@@ -20,12 +47,19 @@ export default function CounterNode({ id, data }: NodeProps<ClientData>) {
     <>
       <div className="bg-white ">
         <Handle type="target" position={Position.Top} />
-        <p className="text-lg font-semibold mb-2">Count: {data.count}</p>
+        <p className="text-lg font-semibold mb-2">Table Count: {data.count}</p>
+        <p className="text-lg font-semibold mb-2">Node Count: {data.count2}</p>
         <button
           className="nodrag bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
-          onClick={incrementCounter}
+          onClick={incrementTableCounter}
         >
-          Increment
+          Increment Table Count
+        </button>
+        <button
+          className="nodrag bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
+          onClick={incrementNodeCounter}
+        >
+          Increment Node Count
         </button>
         <Handle type="source" position={Position.Bottom} />
       </div>


### PR DESCRIPTION
I added another counter stored in the node table to test.

can you check if this implementation is good?

I want the updateData mutation to update partial data and keep the existing data not in the args. But if we have a field in the data that is not optional (foo), we need to define the mutation args as partial. I did not see an obvious way to do this like the Partial<T> in typescript types. Maybe you could create a v.subset ?

Tried this and didn't work:

```
const partialClientData = v.object(
  Object.fromEntries(
    Object.entries(clientData.fields).map(([key, validator]) => [
      key, 
      v.optional(validator)
    ])
  )
);
```

so I created a duplicate partial validator:

```
const partialClientData = v.object({
  count: v.optional(v.number()),
  count2: v.optional(v.number()),
  foo: v.optional(v.string()),
});

export const updateData = mutation({
  args: {
    diagramId: v.string(),
    nodeId: v.string(),
    data: partialClientData,
  },
```

I also had type issues that makes the separate table types a bit fragile:

in App.tsx:88

const nodes = store.getQuery(api.reactflow.nodes.get, { diagramId }) ?? [];
    const newNode = {
      id: args.nodeId,
      position: args.position,
      data: {
        ...args.data,
        count: args.data.count, // Fix type error
      },
      type: "default",
    };
store.setQuery(api.reactflow.nodes.get, { diagramId }, [...nodes, newNode]);
 
The get query has a type `counter: number | undefined `
but args.data has `counter**?**: number | undefined`

---
in the getData function, if I do
`return { count: counter?.count ?? 0, ...node.node.data };`
to avoid listing all the data fields, this will include the counterId field so I can't type it.

to add the type I did:
```
const { counterId: _, ...restData } = node.node.data;
return {
      count: counter?.count ?? 0, ...restData
    } as ClientData;
```